### PR TITLE
Fix frame-tester strategy attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ The tests are run by `runner.html`, which defines the list of tests to run. Edit
 <frame-tester runs="25"></frame-tester>
 ```
 
+By default, the `frame-tester` reports the minumum observed run duration, however this can be configured to report the mean duration within one standard deviation:
+
+```
+<frame-tester strategy="onedev"></frame-tester>
+```
+
 There are two different ways to configure your tests:
 
 ### Using the harness

--- a/perf-lib/frame-tester.html
+++ b/perf-lib/frame-tester.html
@@ -64,9 +64,9 @@
     this.appendChild(document.importNode(this._template.content, true));
     this.frame = this.querySelector('#frame');
     this.log = this.querySelector('#log');
-    this.strategy = this.strategies.minimum;
     this.attributeChangedCallback('runs', null, this.getAttribute('runs') || 25);
     this.attributeChangedCallback('base', null, this.getAttribute('base') || '');
+    this.attributeChangedCallback('strategy', null, this.getAttribute('strategy') || 'minimum');
     window.addEventListener('message', this.scoreMessage.bind(this));
   }
 

--- a/perf-lib/frame-tester.html
+++ b/perf-lib/frame-tester.html
@@ -79,7 +79,10 @@
         this.base = value;
         break;
       case 'strategy':
-        this.strategy = this.strategies[strategy] || this.strategy;
+        var strategy = this.strategies[value];
+        if (strategy) {
+          this.strategy = strategy || this.strategy;
+        }
         break;
     }
   };

--- a/perf-lib/frame-tester.html
+++ b/perf-lib/frame-tester.html
@@ -79,10 +79,8 @@
         this.base = value;
         break;
       case 'strategy':
-        var strategy = this.strategies[value];
-        if (strategy) {
-          this.strategy = strategy || this.strategy;
-        }
+        var strategy = this.strategies[value] || this.strategies.minimum;
+        this.strategy = strategy;
         break;
     }
   };


### PR DESCRIPTION
This change fixes [the issue](https://github.com/PolymerLabs/polyperf/issues/6) related to setting the `strategy` of the `frame-tester`.