### PR TITLE
Deliver message to `parent` instead of `top` window

### DIFF
--- a/perf-lib/perf.js
+++ b/perf-lib/perf.js
@@ -63,7 +63,7 @@ console._perfEnd = function(info) {
     console.timeEnd('perf');
   }
   document.title = time.toFixed(1) + 'ms: ' + document.title;
-  if (window.top !== window) {
-    window.top.postMessage({time: time + 'ms', info: info}, '*');
+  if (window.parent !== window) {
+    window.parent.postMessage({time: time + 'ms', info: info}, '*');
   }
 };


### PR DESCRIPTION
Fixes issue when the performance test is run in nested iframes
for instance when running inside wct.